### PR TITLE
feat: deploy to specific server/client

### DIFF
--- a/src/app/templates/.env.local
+++ b/src/app/templates/.env.local
@@ -10,3 +10,9 @@
 # SAP user credentials
 SAP_USERNAME=<%= userName %>
 SAP_PASSWORD=<%= password %>
+
+# override settings for deployment
+#SAP_DEPLOY_BASE_URL=<%= serverUrl %>
+#SAP_DEPLOY_CLIENT=<%= sapClientForDeployment %>
+#SAP_DEPLOY_USERNAME=
+#SAP_DEPLOY_PASSWORD=

--- a/src/app/templates/.ui5deployrc
+++ b/src/app/templates/.ui5deployrc
@@ -1,7 +1,5 @@
 {
   "cwd": "./dist",
-  "server": "<%= serverUrl %>",
-  "client": "<%= sapClientForDeployment %>",
   "language": "<%= defaultLanguage %>",
   "useStrictSSL": false,
   "package": "<%= package %>",

--- a/src/app/templates/deploy.js
+++ b/src/app/templates/deploy.js
@@ -6,22 +6,52 @@
 import { spawn } from "node:child_process";
 import dotenv from "dotenv";
 
-// Load env vars from .env.local
-dotenv.config({ path: ".env.local" });
-const { SAP_USERNAME, SAP_PASSWORD } = process.env;
+// Load env vars from .env.local and .env (first value set for a variable will win)
+dotenv.config({ path: ['.env.local', '.env'] });
+const {
+  BASE_URL,
+  SAP_CLIENT,
+  SAP_USERNAME,
+  SAP_PASSWORD,
+  SAP_DEPLOY_BASE_URL,
+  SAP_DEPLOY_CLIENT,
+  SAP_DEPLOY_USERNAME,
+  SAP_DEPLOY_PASSWORD,
+} = process.env;
+
+const server = SAP_DEPLOY_BASE_URL || BASE_URL;
+const client = SAP_DEPLOY_CLIENT || SAP_CLIENT;
+
+const user = SAP_DEPLOY_USERNAME || SAP_USERNAME;
+const password = SAP_DEPLOY_PASSWORD || SAP_PASSWORD;
 
 // Validation: env vars must have been set!
-if (!SAP_USERNAME || !SAP_PASSWORD) {
-  console.error("SAP_USERNAME and/or SAP_PASSWORD haven't been set in .env.local!");
+if (!server) {
+  console.error("SAP_DEPLOY_BASE_URL or BASE_URL haven't been set in .env or .env.local!");
+  process.exit(1);
+}
+
+if (!client) {
+  console.error("SAP_DEPLOY_CLIENT or SAP_CLIENT haven't been set in .env or .env.local!");
+  process.exit(1);
+}
+
+if (!user) {
+  console.error("SAP_DEPLOY_USERNAME and/or SAP_USERNAME haven't been set in .env.local!");
+  process.exit(1);
+}
+
+if (!password) {
+  console.error("SAP_DEPLOY_PASSWORD and/or SAP_PASSWORD haven't been set in .env.local!");
   process.exit(1);
 }
 
 // Now deploy using the provided credentials
 const childProcess = spawn(
   "ui5-deployer",
-  ["deploy", "--user", SAP_USERNAME, "--pwd", SAP_PASSWORD],
+  ["deploy", "--server", server, "--client", client, "--user", user, "--pwd", password],
 
-  { shell: true }
+  { shell: true },
 );
 
 // Pass on stdout messages


### PR DESCRIPTION
So far, this is just an idea. It still needs to be properly tested in our projects.

The following is still open:
- customize the generator to ask for the deployment configuration (server, client, username, password)
- better validation for user / password combinations in deploy.js
